### PR TITLE
Allow configuration of sslmode for DB connections

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -6,6 +6,10 @@ Monitor:
   Password: 123456
   DBName: pg_auto_failover
 
+  # sslmode for connecting to the monitor service (Defaults to 'disable')
+  # Reference: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
+  SSLMode: disable
+
 # A list of coordinator nodes that you want to be monitored for changes in their worker nodes.
 Coordinators:
   - DBName: postgres
@@ -14,6 +18,10 @@ Coordinators:
 
     # Formation that the node can be found with in monitor.
     Formation: default
+
+    # sslmode for connecting to the coordinator nodes (Defaults to 'disable')
+    # Reference: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
+    SSLMode: disable
 
 # Service settings
 Settings:

--- a/config/config.go
+++ b/config/config.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/viper"
 )
 
 // ServiceConfig represents the config data for the application.
@@ -17,12 +18,14 @@ type ServiceConfig struct {
 		User     string
 		Password string
 		DBName   string
+		SSLMode  string `default:"disable"`
 	}
 	Coordinators []struct {
 		Formation string
 		Username  string
 		Password  string
 		DBName    string
+		SSLMode   string `default:"disable"`
 	}
 	Settings struct {
 		CheckInterval int

--- a/core/core.go
+++ b/core/core.go
@@ -144,19 +144,19 @@ func (d *database) connect(coordinatorNode *Coordinator) error {
 	if d.db == nil {
 		d.host = coordinatorNode.Host
 		d.port = coordinatorNode.Port
-		d.db, err = openDBConnection(d.host, d.username, d.dbname, d.password, d.port)
+		d.db, err = openDBConnection(d.host, d.username, d.dbname, d.password, d.port, d.sslmode)
 		return err
 	}
 	if d.host != coordinatorNode.Host || d.port != coordinatorNode.Port {
 		logger.CoordinatorChanged(coordinatorNode.Host, d.host, d.dbname, coordinatorNode.Port, d.port)
 		d.host = coordinatorNode.Host
 		d.port = coordinatorNode.Port
-		d.db, err = openDBConnection(d.host, d.username, d.dbname, d.password, d.port)
+		d.db, err = openDBConnection(d.host, d.username, d.dbname, d.password, d.port, d.sslmode)
 		return err
 	}
 	if d.db.Ping() != nil {
 		logger.CoordinatorConnectionLost(d.host, d.dbname, d.username, d.port)
-		d.db, err = openDBConnection(d.host, d.username, d.dbname, d.password, d.port)
+		d.db, err = openDBConnection(d.host, d.username, d.dbname, d.password, d.port, d.sslmode)
 		return err
 	}
 	return nil

--- a/core/db.go
+++ b/core/db.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+
 	"github.com/Navid2zp/citus-failover/config"
 	"github.com/jmoiron/sqlx"
 )
@@ -13,11 +14,13 @@ type database struct {
 	username  string
 	password  string
 	dbname    string
+	sslmode   string `default:"disable"`
 	db        *sqlx.DB
 }
 
 // databases holds the list of all databases to be monitored
 var databases []*database
+
 // monitorDB is database instance for monitor
 var monitorDB *sqlx.DB
 
@@ -28,12 +31,13 @@ func openMonitoringConnection() {
 	monitorDB, err = sqlx.Connect(
 		"postgres",
 		fmt.Sprintf(
-			"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+			"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
 			config.Config.Monitor.Host,
 			config.Config.Monitor.Port,
 			config.Config.Monitor.User,
 			config.Config.Monitor.Password,
 			config.Config.Monitor.DBName,
+			config.Config.Monitor.SSLMode,
 		),
 	)
 	if err != nil {
@@ -51,6 +55,7 @@ func setupDatabases() {
 			username:  db.Username,
 			password:  db.Password,
 			dbname:    db.DBName,
+			sslmode:   db.SSLMode,
 			db:        nil,
 		}
 		databases = append(databases, &coordinator)
@@ -58,16 +63,17 @@ func setupDatabases() {
 }
 
 // openDBConnection opens a database connection.
-func openDBConnection(host, username, dbname, password string, port int) (*sqlx.DB, error) {
+func openDBConnection(host, username, dbname, password string, port int, sslmode string) (*sqlx.DB, error) {
 	return sqlx.Connect(
 		"postgres",
 		fmt.Sprintf(
-			"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+			"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
 			host,
 			port,
 			username,
 			password,
 			dbname,
+			sslmode,
 		),
 	)
 }


### PR DESCRIPTION
Hi @Navid2zp,

As of now the `sslmode` is hardcoded to `disable` which may not cover all use cases.

In our setup our `pg_hba.conf` contains the following:

```
hostssl all             postgres        10.0.0.0/8                  scram-sha-256
```

And this is the error we get when using citus-failover:

```
2021-10-12 20:18:06.633 UTC [392465] postgres [unknown] postgres 10.128.0.3 6165ed7e.5fd11 FATAL:  no pg_hba.conf entry for host "10.128.0.3", user "postgres", database "postgres", SSL off
```

This PR allows the end-user to configure the `sslmode` setting for either the monitor service connection or the coordinators' connections independently.

And if you configure a non-supported mode by `pq` it throws an error like the following:

```
panic: pq: unsupported sslmode "disabled"; only "require" (default), "verify-full", "verify-ca", and "disable" supported
```

I configured the default to be `disable` to be backward compatible.

Let me know what do you think.

Thanks for building this tool!