### PR TITLE
fix: Add new reportedtli column in node table

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -22,6 +22,7 @@ type Node struct {
 	ReportedPGIsRunning bool      `db:"reportedpgisrunning" json:"reported_pg_is_running"`
 	ReportedRepState    string    `db:"reportedrepstate" json:"reported_rep_state"`
 	ReportTime          time.Time `db:"reporttime" json:"report_time"`
+	ReportedTLI         int       `db:"reportedtli" json:"reported_tli"`
 	ReportedLSN         string    `db:"reportedlsn" json:"reported_lsn"`
 	WALReportTime       time.Time `db:"walreporttime" json:"wal_report_time"`
 	Health              int       `db:"health" json:"health"`


### PR DESCRIPTION
Hi @Navid2zp ,

`pg_auto_failover` added a `reportedtli` column in node table in version 1.6, so this
commit fixes it for newer versions.

This is the error I am getting:

```
{"level":"error","ts":1634069583.9079251,"caller":"logging/core.go:54","msg":"failed to check if worker is primary!","service":"core","database":"postgres","error":"missing destination name reportedtli in *core.Node","worker-id":3,"stacktrace":"github.com/Navid2zp/citus-failover/logging.(*Logger).WorkerPrimaryCheckFailed\n\t/home/amontalban/dev/citus-failover/logging/core.go:54\ngithub.com/Navid2zp/citus-failover/core.(*database).validateWorker\n\t/home/amontalban/dev/citus-failover/core/tasks.go:13"}
```

Reference: https://github.com/citusdata/pg_auto_failover/pull/730