### PR TITLE
chore: Rename Logger service name

### DIFF
--- a/core/init.go
+++ b/core/init.go
@@ -16,7 +16,7 @@ var logger *logging.Logger
 func InitMonitor() {
 	openMonitoringConnection()
 	setupDatabases()
-	logger = logging.NewLogger("core")
+	logger = logging.NewLogger("citus-failover")
 }
 
 // NullInt64 is an alias for sql.NullInt64 data type


### PR DESCRIPTION
Logging system is using `core` as service name and I think it would be better to be renamed to `citus-failover` so logged JSON information will show up like:

```json
{"level":"info","ts":1634923402.7779536,"caller":"logging/core.go:70","msg":"worker updated","service":"citus-failover","database":"postgres","old-worker":"citus-andres-dev-data-2-b-79s5.c.qa01.internal:5432","new-worker":"citus-andres-dev-data-2-a-3vcj.c.qa01.internal:5432"}
```

Instead of currently showing up as:

```json
{"level":"info","ts":1634923402.7779536,"caller":"logging/core.go:70","msg":"worker updated","service":"core","database":"postgres","old-worker":"citus-andres-dev-data-2-b-79s5.c.qa01.internal:5432","new-worker":"citus-andres-dev-data-2-a-3vcj.c.qa01.internal:5432"}
```

This helps to get log search automatically set up in services like Datadog/NewRelic/ElasticSearch.

Thanks!